### PR TITLE
Inplace operation rewrite

### DIFF
--- a/examples/mnist/src/model.zig
+++ b/examples/mnist/src/model.zig
@@ -94,9 +94,9 @@ pub fn LinearLayer(comptime T: type) type {
         pub fn forward(self: *const Self, x: *Tensor) !*Tensor {
             const batch_size = if (x.data.shape.len > 1) x.get_dim(0) else 1;
             const n_features = self.weights.data.shape.get(0);
-            const output = try x.bmm_acc(self.weights, &.{ batch_size, n_features }, .{ .trans_b = true });
-            try self.bias.add_(output);
-            return output;
+            const y = try x.bmm_acc(self.weights, &.{ batch_size, n_features }, .{ .trans_b = true });
+            try self.bias.add_(y);
+            return y;
         }
     };
 }

--- a/src/backward_context.zig
+++ b/src/backward_context.zig
@@ -63,16 +63,89 @@ const ClosurePointer = struct {
     }
 };
 
-pub fn BackwardContext(PrimaryType: type) type {
+pub fn BackwardChildren(ChildType: type) type {
     return struct {
         const Self = @This();
-        const ContextPtr = ?*anyopaque;
-        const ContextFunction = *const fn (*Self, *PrimaryType) anyerror!void;
-        // small-buffer-optimized context object
-        const SmallBuffer = [4]usize;
+        pub const Slice = []ChildType;
+        pub const ChildIterator = struct {};
+        pub const capacity: u64 = 8;
+        buffer: [capacity]ChildType = undefined,
+        len: usize = 0,
+
+        pub fn init(children: []const ChildType) Self {
+            std.debug.assert(Self.capacity >= children.len);
+            var self: Self = .{};
+            self.len = children.len;
+            @memcpy(self.buffer[0..self.len], children);
+            return self;
+        }
+
+        pub fn get(self: *const Self, i: usize) ChildType {
+            std.debug.assert(i < self.len);
+            return self.buffer[i];
+        }
+
+        pub fn get_bwd(self: *const Self, i: usize) ?ChildType {
+            return if (self.get(i).requires_grad())
+                self.buffer[i]
+            else
+                null;
+        }
+
+        /// Remove all elements from the slice.
+        pub fn clear(self: *Self) void {
+            self.len = 0;
+        }
+    };
+}
+pub fn Iterator(ContextType: type) type {
+    return struct {
+        const Self = @This();
+        node: ?*ContextType,
+
+        pub fn next(self: *Self) ?*ContextType {
+            if (self.node) |node| {
+                defer self.node = node.next;
+                return node;
+            }
+            return null;
+        }
+    };
+}
+
+pub fn ChildIterator(ContextType: type) type {
+    return struct {
+        const Self = @This();
+        node: ?*ContextType,
+        index: usize = 0,
+
+        pub fn next(self: *Self) ?*ContextType.PrimaryType {
+            if (self.node) |node| {
+                if (self.index < node.children.len) {
+                    defer self.index += 1;
+                    return node.children.buffer[self.index];
+                }
+                self.node = node.next;
+                self.index = 0;
+                return self.next();
+            }
+            return null;
+        }
+    };
+}
+
+pub fn BackwardContext(primary_type: type) type {
+    return struct {
+        const Self = @This();
+        pub const PrimaryType = primary_type;
+        pub const ContextPtr = ?*anyopaque;
+        pub const ContextFunction = *const fn (*Self, *PrimaryType) anyerror!void;
+        pub const Children = BackwardChildren(*PrimaryType);
+        pub const SmallBuffer = [4]usize;
 
         debug_id: if (debug) usize else void,
         callable: ContextFunction,
+        children: Children,
         persist: bool = false,
         storage: union(enum) {
             none: void,
@@ -80,8 +153,17 @@ pub fn BackwardContext(PrimaryType: type) type {
             ptr: ClosurePointer,
             ref: *anyopaque,
         } = .none,
+        next: ?*Self = null,
 
-        pub fn init(CtxType: type, context: CtxType, persist: bool, device: DeviceReference) !Self {
+        pub fn init(
+            CtxType: type,
+            context: CtxType,
+            device: DeviceReference,
+            config: struct {
+                children: ?[]const *PrimaryType = null,
+                persist: bool = false,
+            },
+        ) !Self {
             const is_ref = (@typeInfo(CtxType) == .pointer);
             const ArgType = if (is_ref) std.meta.Child(CtxType) else CtxType;
 
@@ -92,11 +174,11 @@ pub fn BackwardContext(PrimaryType: type) type {
             const callback = struct {
                 pub fn wrapper(_self: *Self, x: *PrimaryType) anyerror!void {
                     switch (comptime arity(ArgType.callback)) {
-                        1 => {
-                            try ArgType.callback(x);
-                        },
                         2 => {
-                            try ArgType.callback(x, _self.cast(ArgType));
+                            try ArgType.callback(x, &_self.children);
+                        },
+                        3 => {
+                            try ArgType.callback(x, &_self.children, _self.cast(ArgType));
                         },
                         else => {
                             @compileError("backward callback must have artiy within [1,2]");
@@ -105,19 +187,23 @@ pub fn BackwardContext(PrimaryType: type) type {
                 }
             }.wrapper;
 
+            const children: Children = if (config.children) |c| Children.init(c) else .{};
+
             if (is_ref) {
                 return .{
-                    .callable = callback,
-                    .storage = .{ .ref = context },
                     .debug_id = if (debug) type_id(ArgType) else {},
-                    .persist = persist,
+                    .callable = callback,
+                    .children = children,
+                    .storage = .{ .ref = context },
+                    .persist = config.persist,
                 };
             }
 
             var tmp: Self = .{
-                .callable = callback,
                 .debug_id = if (debug) type_id(ArgType) else {},
-                .persist = persist,
+                .callable = callback,
+                .children = children,
+                .persist = config.persist,
             };
 
             const arg_size = @sizeOf(ArgType);
@@ -140,13 +226,34 @@ pub fn BackwardContext(PrimaryType: type) type {
             return tmp;
         }
 
+        pub fn prepend(root: *Self, new_root: Self, device: DeviceReference) !void {
+            const next_ptr = try device.allocator.create(Self);
+            next_ptr.* = root.*;
+            root.* = new_root;
+            root.next = next_ptr;
+        }
+
         pub fn deinit(self: *Self, device: DeviceReference) void {
+            if (self.next) |next| {
+                next.deinit(device);
+                device.allocator.destroy(next);
+            }
             self.release(device);
-            self.* = undefined;
+        }
+
+        pub fn iterator(self: *Self) Iterator(Self) {
+            return .{ .node = self };
+        }
+
+        pub fn child_iterator(self: *Self) ChildIterator(Self) {
+            return .{ .node = self };
         }
 
         pub fn call(self: *Self, tensor: *PrimaryType) anyerror!void {
-            return self.callable(self, tensor);
+            var _this: ?*Self = self;
+            while (_this) |this| : (_this = this.next) {
+                try this.callable(this, tensor);
+            }
         }
 
         pub fn release(self: *Self, device: DeviceReference) void {

--- a/src/backward_context.zig
+++ b/src/backward_context.zig
@@ -181,7 +181,8 @@ pub fn BackwardContext(primary_type: type) type {
                             try ArgType.callback(x, &_self.children, _self.cast(ArgType));
                         },
                         else => {
-                            @compileError("backward callback must have artiy within [1,2]");
+                            @compileLog(@typeName(ArgType));
+                            @compileError("backward callback must have artiy within [2,3]");
                         },
                     }
                 }

--- a/src/graph_manager.zig
+++ b/src/graph_manager.zig
@@ -38,11 +38,11 @@ pub fn GraphManager(comptime T: type) type {
         fn topo(self: *Self, node: *T) void {
             const gopr = self.visited_nodes.getOrPut(node) catch unreachable;
             if (!gopr.found_existing) {
-                if (node.get_children()) |children| {
-                    for (children) |child| {
-                        if (!child.attached) continue;
-                        self.topo(child);
-                    }
+                const bwd_ctx = &(node._backward_ctx orelse return);
+                var children = bwd_ctx.child_iterator();
+                while (children.next()) |child| {
+                    if (!child.attached) continue;
+                    self.topo(child);
                 }
                 self.sorted_nodes.append(node) catch unreachable;
             }

--- a/src/nn/optim.zig
+++ b/src/nn/optim.zig
@@ -58,10 +58,12 @@ pub fn SGD(comptime T: type) type {
 
         pub fn attach(self: *Self, param: *Tensor) !void {
             std.debug.assert(param._backward_ctx == null);
-            param._backward_ctx = try Tensor.BackwardsContext.init(*Self, self, true, param.device);
+            param._backward_ctx = try Tensor.BackwardsContext.init(*Self, self, param.device, .{
+                .persist = true,
+            });
         }
 
-        pub fn callback(param: *Tensor, self: *Self) !void {
+        pub fn callback(param: *Tensor, _: *Tensor.Children, self: *Self) !void {
             // std.debug.print("IN SGD BACKWARD\n", .{});
 
             if (self.grad_clip_enabled) param._clip_grad_norm(.{


### PR DESCRIPTION
Moves children into the backward context, creates a new iterator, and fixes our shared memory model. Instead of creating shell tensors, we can use backward contexts like linked lists. This allows us to stack contexts horizontally on a sink node. For reference, consider the following:
```zig
x := zeros
a := ones
b := ones
a.add_(x) // add backward context to x
b.add_(x) // add backward context to x
```
Now x has a linked list of backwards contexts that form a lateral graph:
```zig
         b          a
         ^          ^
         |          |         
x ---> ctx_1 ---> ctx_0 
```
Thus if we imagine that x was the creation of `op(u,v)` then, we get:
```zig
                           u     v
         b          a       \   /
         ^          ^        \ /
         |          |         | 
x ---> ctx_2 ---> ctx_1 ---> ctx_0 
```