### PR TITLE
Update Lifetimes and Graph Ownership

### DIFF
--- a/examples/mnist/src/main-simple.zig
+++ b/examples/mnist/src/main-simple.zig
@@ -67,7 +67,7 @@ pub fn run_mnist(train_path: []const u8, test_path: []const u8) !void {
                 ms_per_sample,
             });
 
-            graph.reset();
+            graph.reset(.internal);
         }
         const avg_loss = total_loss / @as(f32, @floatFromInt(train_dataset.images.len));
         std.debug.print("Epoch {d}: Avg Loss = {d:.4}\n", .{ epoch + 1, avg_loss });
@@ -101,7 +101,7 @@ fn eval_mnist(graph: *zg.Graph, model: *MnistModel(T), dataset: MnistDataset(T))
     for (dataset.images, dataset.labels) |image, label| {
         const output = try model.forward(image);
         defer output.deinit();
-        defer graph.reset();
+        defer graph.reset(.internal);
         const batch_n = output.data.shape.get(0);
         for (0..batch_n) |j| {
             const start = j * 10;

--- a/examples/mnist/src/model.zig
+++ b/examples/mnist/src/model.zig
@@ -40,19 +40,19 @@ pub fn MnistModel(comptime T: type) type {
             try zg.nn.relu_(T, z0);
 
             if (!flat.requires_grad())
-                flat.clear();
+                flat.deinit();
 
             const z1 = try self.linear_layers[1].forward(z0);
             errdefer z1.deinit();
             try zg.nn.relu_(T, z1);
 
             if (!z0.requires_grad())
-                z0.clear();
+                z0.deinit();
 
             const z2 = try self.linear_layers[2].forward(z1);
 
             if (!z1.requires_grad())
-                z1.clear();
+                z1.deinit();
 
             return z2;
         }

--- a/src/graph/arena_unmanaged.zig
+++ b/src/graph/arena_unmanaged.zig
@@ -41,6 +41,17 @@ pub fn create(self: *ArenaUnmanaged, allocator: Allocator, comptime T: type) Err
     return ptr;
 }
 
+/// Modified from standard library allocator interface
+pub fn destroy(self: *ArenaUnmanaged, ptr: anytype) void {
+    const cur_node = self.buffer_list.first orelse return;
+    const cur_buf = @as([*]u8, @ptrCast(cur_node))[@sizeOf(BufNode)..cur_node.data];
+    const buf = std.mem.asBytes(ptr);
+
+    if (@intFromPtr(cur_buf.ptr) + self.end_index == @intFromPtr(buf.ptr) + buf.len) {
+        self.end_index -= buf.len;
+    }
+}
+
 /// Queries the current memory use of this arena.
 /// This will **not** include the storage required for internal keeping.
 pub fn query_capacity(self: ArenaUnmanaged) usize {

--- a/src/graph/node.zig
+++ b/src/graph/node.zig
@@ -75,6 +75,7 @@ pub fn clear(self: *Node) void {
         bwd.deinit(self.gb.allocator);
         self.callbacks.bwd = null;
     }
+    self.flags.set(.active, false);
 }
 
 pub fn is_leaf(self: *const Node) bool {
@@ -124,6 +125,10 @@ pub fn acquired(self: *const Node) bool {
     return self.flags.get(.acquired);
 }
 
+pub fn active(self: *const Node) bool {
+    return self.flags.get(.active);
+}
+
 pub fn attached(self: *const Node) bool {
     return self.flags.get(.attached);
 }
@@ -152,6 +157,14 @@ pub const Flags = struct {
         /// not be freed. Set by using the "acquire" and
         /// "release" functions.
         acquired,
+        /// This field describes whether `deinit` has been
+        /// already called on the parent object.
+        /// This makes it easier to handle releasing memory
+        /// on errors if intermediate tensors were freed.
+        /// The parent object is responsible for setting
+        /// this field. It is undefined behavior to use an
+        /// object that is attched to an inactive node.
+        active,
         /// An attached tensor can be traversed through
         /// in the backward process. If the tensor is
         /// unattached, the reversal process will not
@@ -174,7 +187,8 @@ pub const Flags = struct {
     pub fn init(node_category: Category, config: Config) Flags {
         var self: Flags = .empty;
         self.set(.category, node_category == .leaf);
-        comptime var field_count: usize = 1;
+        self.set(.active, true);
+        comptime var field_count: usize = 2;
         inline for (std.meta.fields(@TypeOf(config))) |field| {
             const tag = comptime std.meta.stringToEnum(Values, field.name) orelse continue;
 


### PR DESCRIPTION
- Added second arena for leaf nodes
- Added destroy method to rollback failed allocations
- Removed `clear` in favor of `deinit`
- Added optional reset methods for leaves and internal nodes