### PR TITLE
Memory Safety

### DIFF
--- a/examples/mnist/src/model.zig
+++ b/examples/mnist/src/model.zig
@@ -37,19 +37,19 @@ pub fn MnistModel(comptime T: type) type {
             errdefer z0.deinit();
             try zg.nn.relu_(T, z0);
 
-            if (!flat.requires_grad())
+            if (flat.should_deinit())
                 flat.deinit();
 
             const z1 = try self.linear_layers[1].forward(z0);
             errdefer z1.deinit();
             try zg.nn.relu_(T, z1);
 
-            if (!z0.requires_grad())
+            if (z0.should_deinit())
                 z0.deinit();
 
             const z2 = try self.linear_layers[2].forward(z1);
 
-            if (!z1.requires_grad())
+            if (z1.should_deinit())
                 z1.deinit();
 
             return z2;

--- a/src/device/cuda_device.zig
+++ b/src/device/cuda_device.zig
@@ -16,9 +16,9 @@ pub const CudaMalloc = struct {
         const w: *cuda.StreamWrapper = @ptrCast(@alignCast(ctx));
         return @ptrCast(@alignCast(cuda.mem_alloc(n, w.*)));
     }
-    pub fn raw_free(ptr: ?*anyopaque, ctx: *anyopaque) void {
+    pub fn raw_free(buf: []u8, ctx: *anyopaque) void {
         const w: *cuda.StreamWrapper = @ptrCast(@alignCast(ctx));
-        cuda.mem_free(ptr, w.*);
+        cuda.mem_free(buf.ptr, w.*);
     }
 };
 

--- a/src/device/host_device.zig
+++ b/src/device/host_device.zig
@@ -29,10 +29,16 @@ const c = switch (builtin.target.os.tag) {
 
 pub const HostMalloc = struct {
     pub fn raw_alloc(n: usize, _: *anyopaque) ?[*]u8 {
+        if (comptime builtin.is_test) {
+            return std.testing.allocator.rawAlloc(n, @enumFromInt(@alignOf(usize)), @returnAddress());
+        }
         return @ptrCast(@alignCast(std.c.malloc(n) orelse return null));
     }
-    pub fn raw_free(ptr: ?*anyopaque, _: *anyopaque) void {
-        return std.c.free(ptr);
+    pub fn raw_free(buf: []u8, _: *anyopaque) void {
+        if (comptime builtin.is_test) {
+            return std.testing.allocator.rawFree(buf, @enumFromInt(@alignOf(usize)), @returnAddress());
+        }
+        return std.c.free(buf.ptr);
     }
 };
 

--- a/src/graph.zig
+++ b/src/graph.zig
@@ -116,7 +116,9 @@ test "Graph eager teardown reuse 1" {
 
     const device = cpu.reference();
 
-    var graph = Graph.init(std.testing.allocator, .{});
+    var graph = Graph.init(std.testing.allocator, .{
+        .eager_teardown = true,
+    });
     defer graph.deinit();
 
     const opts: TensorOpts = .{
@@ -170,7 +172,9 @@ test "Graph eager teardown reuse 2" {
 
     const device = cpu.reference();
 
-    var graph = Graph.init(std.testing.allocator, .{});
+    var graph = Graph.init(std.testing.allocator, .{
+        .eager_teardown = true,
+    });
     defer graph.deinit();
 
     const opts: TensorOpts = .{
@@ -221,7 +225,9 @@ test "Graph x*x" {
 
     const device = cpu.reference();
 
-    var graph = Graph.init(std.testing.allocator, .{});
+    var graph = Graph.init(std.testing.allocator, .{
+        .eager_teardown = true,
+    });
     defer graph.deinit();
 
     const opts: TensorOpts = .{

--- a/src/ndtensor.zig
+++ b/src/ndtensor.zig
@@ -132,6 +132,16 @@ pub fn NDTensor(comptime T: type) type {
             self.node.flags.set(.acquired, false);
         }
 
+        /// This function should be checked by the user to see
+        /// if they should deinitialize the memory on a forward
+        /// pass. If the tensor requires a gradient, then it must
+        /// exist for the backward pass to function. Likewise,
+        /// acquired memory should never be deinitialized without
+        /// first calling "release" .
+        pub fn should_deinit(self: *const Self) bool {
+            return !(self.acquired() or self.requires_grad());
+        }
+
         pub fn backward(self: *Self) !void {
             std.debug.assert(zg.rt_grad_enabled);
             const graph = self.node.gb.promote();
@@ -1294,6 +1304,7 @@ test "tensor/Graph/sum" {
     defer input.deinit();
 
     const sum_result = try input.sum();
+    defer sum_result.deinit();
 
     try std.testing.expectEqualSlices(f32, &.{10}, sum_result.get_data());
 


### PR DESCRIPTION
- Integrate `std.testing.allocator` when running tests on the HostDevice
- Fix all memory leaks for tests.
- add `should_deinit` member function to clarify intermediate tensors control